### PR TITLE
56 ensuring both windows and mac os users have the same git line ending configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,33 @@
+# Ensure all text files use LF line endings
+* text=auto eol=lf
+
+# Explicitly enforce LF for common text-based files
+*.c text eol=lf
+*.cpp text eol=lf
+*.h text eol=lf
+*.java text eol=lf
+*.py text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.css text eol=lf
+*.html text eol=lf
+*.xml text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+*.sh text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.sql text eol=lf
+
+# Keep binary files untouched
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.exe binary
+*.dll binary
+*.mp4 binary
+*.mp3 binary


### PR DESCRIPTION
This PR is to add .gitattribute file to the root repository directory.
It helps both windows and mac os users to align the line ending, so that all team members could avoid line ending difference that may contribute to many unnecessary merge conflicts.