### PR TITLE
Add admin stats route for admin dashboard metrics

### DIFF
--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -50,4 +50,57 @@ const promoteToAdmin = async (req, res) => {
     }
 };
 
-module.exports = { promoteToAdmin };
+// Stats for the admin dashboard
+const getAdminStats = async (req, res) => {
+    try {
+        // Count tasks by status
+        const toDoQuery = await client.query("SELECT COUNT(*) FROM tasks WHERE status = 'To-Do'");
+        const inProgressQuery = await client.query("SELECT COUNT(*) FROM tasks WHERE status = 'In Progress'");
+        const doneQuery = await client.query("SELECT COUNT(*) FROM tasks WHERE status = 'Done'");
+        // Parse to Int
+        const toDoTotal = parseInt(toDoQuery.rows[0].count, 10);
+        const inProgressTotal = parseInt(inProgressQuery.rows[0].count, 10);
+        const doneTotal = parseInt(doneQuery.rows[0].count, 10);
+
+        // Calculate the completion rate of tasks
+        const totalTasks = toDoTotal + inProgressTotal + doneTotal;
+        const completionRate = totalTasks > 0 ? ((doneTotal / totalTasks) * 100).toFixed(2) : 0;
+
+        // Count upcoming due tasks (set this to be the next 7 days, can be changed)
+        const upcomingDueQuery = await client.query(`
+            SELECT COUNT(*) FROM tasks 
+            WHERE due_date >= NOW() 
+            AND due_date <= NOW() + INTERVAL '7 days' 
+            AND status != 'Done'
+        `);
+        const upcomingDueTotal = parseInt(upcomingDueQuery.rows[0].count, 10);
+
+        // Get the most recent upcoming due date that excludes "Done" tasks
+        const upcomingDueDateQuery = await client.query(`
+            SELECT due_date FROM tasks
+            WHERE due_date >= NOW()
+            AND status != 'Done'
+            ORDER BY due_date ASC
+            LIMIT 1
+        `);
+        const upcomingDueDate = upcomingDueDateQuery.rows.length > 0 ? upcomingDueDateQuery.rows[0].due_date : null;
+        
+        // Send the data/response
+        res.json({
+            todo: toDoTotal,
+            inProgress: inProgressTotal,
+            done: doneTotal,
+            completionRate: completionRate,
+            upcomingDue: upcomingDueTotal,
+            upcomingDueDate: upcomingDueDate
+        });
+
+    } catch (error) {
+        console.error('Error fetching admin stats:', error);
+        return res.status(500).json({ 
+            error: 'Internal Server Error',
+            message: 'An unexpected error occurred while processing your request. Please try again later.' });
+    }
+};
+
+module.exports = { promoteToAdmin, getAdminStats };

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -7,6 +7,6 @@ const router = express.Router();
 
 // Promote user to admin route with validation middleware
 router.post('/promote', validateAdmin, promoteToAdmin);
-router.get('/stats', getAdminStats);
+router.get('/stats', validateAdmin, getAdminStats);
 
 module.exports = router;

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const { promoteToAdmin } = require('../controllers/adminController');
 const { validateAdmin } = require('../middlewares/validateAdmin');
+const { getAdminStats } = require('../controllers/adminController');
 
 const router = express.Router();
 
 // Promote user to admin route with validation middleware
 router.post('/promote', validateAdmin, promoteToAdmin);
+router.get('/stats', getAdminStats);
 
 module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -18,6 +18,7 @@ app.use(express.json());
 // routes
 app.use("/auth", require("./routes/auth"));
 app.use("/register", require("./routes/userRoutes"));
+app.use("/admin", require("./routes/adminRoutes"));
 
 // Basic Route
 app.get("/", (req, res) => {

--- a/backend/src/tests/getAdminStats.test.js
+++ b/backend/src/tests/getAdminStats.test.js
@@ -1,0 +1,109 @@
+const request = require('supertest');
+const express = require('express');
+const { getAdminStats } = require('../controllers/adminController');
+const { Client } = require('pg');
+
+// Mock pg client (not using real database in tests)
+jest.mock('pg', () => {
+    const mockClient = {
+        connect: jest.fn(),
+        query: jest.fn(),
+        end: jest.fn(),
+    };
+    return { Client: jest.fn(() => mockClient) };
+});
+
+const app = express();
+app.use(express.json());
+app.get('/admin/stats', getAdminStats);
+
+describe('GET /admin/stats', () => {
+    let client;
+
+    beforeAll(() => {
+        client = new Client();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // Test case: Admin stats should be returned correctly when on Admin Dashboard
+    test('should return admin stats successfully', async () => {
+        client.query
+            .mockResolvedValueOnce({ rows: [{ count: '5' }] }) // toDoQuery
+            .mockResolvedValueOnce({ rows: [{ count: '3' }] }) // inProgressQuery
+            .mockResolvedValueOnce({ rows: [{ count: '2' }] }) // doneQuery
+            .mockResolvedValueOnce({ rows: [{ count: '4' }] }) // upcomingDueQuery
+            .mockResolvedValueOnce({ rows: [{ due_date: '2023-12-01' }] }); // upcomingDueDateQuery
+
+        const res = await request(app).get('/admin/stats');
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body).toEqual({
+            todo: 5,
+            inProgress: 3,
+            done: 2,
+            completionRate: '20.00',
+            upcomingDue: 4,
+            upcomingDueDate: '2023-12-01',
+        });
+    });
+
+    // Test case: The errors should be gracefully handled
+    test('should handle errors gracefully', async () => {
+        client.query.mockRejectedValueOnce(new Error('Database error'));
+
+        const res = await request(app).get('/admin/stats');
+
+        expect(res.statusCode).toEqual(500);
+        expect(res.body).toEqual({
+            error: 'Internal Server Error',
+            message: 'An unexpected error occurred while processing your request. Please try again later.',
+        });
+    });
+
+    // Test case: If no data is present, then it should return zeros
+    test('should return zero stats when no data is available', async () => {
+        client.query
+            .mockResolvedValueOnce({ rows: [{ count: '0' }] }) // toDoQuery
+            .mockResolvedValueOnce({ rows: [{ count: '0' }] }) // inProgressQuery
+            .mockResolvedValueOnce({ rows: [{ count: '0' }] }) // doneQuery
+            .mockResolvedValueOnce({ rows: [{ count: '0' }] }) // upcomingDueQuery
+            .mockResolvedValueOnce({ rows: [] }); // upcomingDueDateQuery
+
+        const res = await request(app).get('/admin/stats');
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body).toEqual({
+            todo: 0,
+            inProgress: 0,
+            done: 0,
+            completionRate: 0,
+            upcomingDue: 0,
+            upcomingDueDate: null,
+        });
+    });
+
+    // Test case: Not all data is available for each task. Should handle it gracefully
+    test('should handle partial data gracefully', async () => {
+        client.query
+            .mockResolvedValueOnce({ rows: [{ count: '5' }] }) // toDoQuery
+            .mockResolvedValueOnce({ rows: [{ count: '3' }] }) // inProgressQuery
+            .mockResolvedValueOnce({ rows: [{ count: '2' }] }) // doneQuery
+            .mockResolvedValueOnce({ rows: [{ count: '0' }] }) // upcomingDueQuery
+            .mockResolvedValueOnce({ rows: [] }); // upcomingDueDateQuery
+
+        const res = await request(app).get('/admin/stats');
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body).toEqual({
+            todo: 5,
+            inProgress: 3,
+            done: 2,
+            completionRate: '20.00',
+            upcomingDue: 0,
+            upcomingDueDate: null,
+        });
+    });
+});


### PR DESCRIPTION
Implemented the backend for Admin stats/metrics for the Admin Dashboard.
- Queries the database to count the total number of tasks with statuses "To-Do", "In Progress", "Done".
- Adds the totals queried above to have a total amount of tasks for the completion rate metric.
- Queries the database to find the most recent upcoming due task.
- Queries the database to find the total amount of tasks due within a 7 day period.

Added unit tests to verify functionality:
- Ensures that the number of tasks per status category are correctly returned.
- Errors are gracefully handled (providing an error message).
- Zeros should be returned if no data is present.
- Partial data should be gracefully handled.

Closes #7 