### PR TITLE
Refactor frontend tests

### DIFF
--- a/frontend/src/_tests_/AdminManagement.test.js
+++ b/frontend/src/_tests_/AdminManagement.test.js
@@ -5,7 +5,6 @@ import { useNavigate } from "react-router-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-// Mock data for users
 const mockUsers = [
     { id: 1, firstName: "John", lastName: "Doe", email: "john@example.com" },
     { id: 2, firstName: "Jane", lastName: "Smith", email: "jane@example.com" },
@@ -25,19 +24,16 @@ const renderAdminManagement = () => {
     );
 };
 
-// Mocking `AdminManagement` Component
 const MockAdminManagement = ({ users }) => {
     const navigate = useNavigate();
 
     const handlePromote = (userId) => {
-        // Simulate promoting the user to admin
         users = users.map((user) =>
             user.user_id === userId ? { ...user, is_admin: true } : user
         );
     };
 
     const handleDelete = (userId) => {
-        // Simulate deleting the user
         users = users.filter((user) => user.user_id !== userId);
     };
 
@@ -86,7 +82,6 @@ const MockAdminManagement = ({ users }) => {
 
 describe("AdminManagement", () => {
     let navigate;
-    let mockPromote;
 
     // set up for each test
     beforeEach(() => {
@@ -118,13 +113,13 @@ describe("AdminManagement", () => {
 
     test("promotes user to admin", async () => {
         // Set up a mock function to update users
-        const setUsers = jest.fn();  // Mock state update function
+        const setUsers = jest.fn();
 
         render(<MockAdminManagement users={mockUsers} setUsers={setUsers} />);
 
         // find the first "Promote to Admin" button (for a specific user)
         const promoteButtons = screen.getAllByText(/Promote/i);
-        const firstPromoteButton = promoteButtons[0]; // Promote the first user
+        const firstPromoteButton = promoteButtons[0];
 
         await userEvent.click(firstPromoteButton);
 
@@ -132,11 +127,10 @@ describe("AdminManagement", () => {
         // Here we simulate what would happen after the promote action is completed
         setUsers.mockImplementationOnce(() => {
             const updatedUsers = [...mockUsers];
-            updatedUsers[0].is_admin = true; // First user becomes an admin
+            updatedUsers[0].is_admin = true;
             return updatedUsers;
         });
 
-        // Ensure that at least one "admin" label exists
         expect(screen.getAllByText(/admin/i).length).toBeGreaterThan(0);
     });
 
@@ -146,7 +140,6 @@ describe("AdminManagement", () => {
         const dashboardButton = screen.getByText(/Go to Dashboard/i);
         await userEvent.click(dashboardButton);
 
-        // wait for navigation to be triggered
         await waitFor(() => {
             expect(navigate).toHaveBeenCalledWith("/tasks");
         });

--- a/frontend/src/_tests_/AdminPage.test.js
+++ b/frontend/src/_tests_/AdminPage.test.js
@@ -129,7 +129,7 @@ const MockAdminDashboard = () => {
             key={status}
             title={status}
             tasks={tasks[status]}
-            onToggleLock={handleToggleLock} // Mocked function
+            onToggleLock={handleToggleLock}
           />
         ))}
       </div>
@@ -140,7 +140,6 @@ const MockAdminDashboard = () => {
   );
 };
 
-// add render function that can be called by the tests instead of having the render in each test
 const renderMockAdminManagement = () => {
   render(
     <Router>
@@ -178,7 +177,7 @@ describe("AdminDashboard Component", () => {
     await waitFor(() => expect(screen.getByText("Add New Task")).toBeInTheDocument());
 
     fireEvent.change(screen.getByPlaceholderText("Task Title"), { target: { value: "New Task" } });
-    fireEvent.click(screen.getByText("Add Task")); // Ensure this matches the button text
+    fireEvent.click(screen.getByText("Add Task"));
 
     // Ensure the new task appears in the To-Do column
     await waitFor(() => expect(screen.getByText("New Task")).toBeInTheDocument());
@@ -188,7 +187,6 @@ describe("AdminDashboard Component", () => {
   test("toggles task lock state", async () => {
     renderMockAdminManagement();
   
-    // Wait for tasks to load
     await waitFor(() => expect(screen.getByText("Mock Task 1")).toBeInTheDocument());
   
     // Find the lock toggle button for Task 1
@@ -196,13 +194,11 @@ describe("AdminDashboard Component", () => {
     expect(lockButtons[0]).toHaveTextContent("Lock");
     expect(lockButtons.length).toBeGreaterThan(0);
   
-    // Click the lock toggle
     fireEvent.click(lockButtons[0]);
   
     // Ensure button text changes
     await waitFor(() => expect(lockButtons[0]).toHaveTextContent("Locked"));
 
-    // Click again to unlock
     fireEvent.click(lockButtons[0]);
 
     // Ensure button text changes back

--- a/frontend/src/_tests_/AdminPage.test.js
+++ b/frontend/src/_tests_/AdminPage.test.js
@@ -140,6 +140,15 @@ const MockAdminDashboard = () => {
   );
 };
 
+// add render function that can be called by the tests instead of having the render in each test
+const renderMockAdminManagement = () => {
+  render(
+    <Router>
+        <MockAdminDashboard />
+    </Router>
+  );
+};
+
 describe("AdminDashboard Component", () => {
   beforeEach(() => {
     fetch.mockClear();
@@ -162,11 +171,7 @@ describe("AdminDashboard Component", () => {
 
 
   test("adds a new task", async () => {
-    render(
-      <Router>
-        <MockAdminDashboard />
-      </Router>
-    );
+    renderMockAdminManagement();
 
     fireEvent.click(screen.getByText("+ Add Task"));
 
@@ -181,11 +186,7 @@ describe("AdminDashboard Component", () => {
 
   // test to ensure that the task is locked when toggled
   test("toggles task lock state", async () => {
-    render(
-      <Router>
-        <MockAdminDashboard />
-      </Router>
-    );
+    renderMockAdminManagement();
   
     // Wait for tasks to load
     await waitFor(() => expect(screen.getByText("Mock Task 1")).toBeInTheDocument());

--- a/frontend/src/_tests_/AdminPage.test.js
+++ b/frontend/src/_tests_/AdminPage.test.js
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
-import AdminDashboard from "../components/AdminDashboard";
 import AdminTaskList from "../components/AdminTaskList";
 import SearchBar from "../components/SearchBar";
 import AddTask from "../components/AddTask";
@@ -33,10 +32,9 @@ global.fetch = jest.fn((url, options) => {
   });
 });
 
-const MockAdminDashboard = () => {
+const useMockAdminDashboard = () => {
   const navigate = useNavigate();
 
-  // Mock states instead of fetching data
   const [tasks, setTasks] = useState({
     todo: [{ id: 1, title: "Mock Task 1", status: "todo", locked: false }],
     inProgress: [],
@@ -54,7 +52,6 @@ const MockAdminDashboard = () => {
     upcomingDue: 0,
   });
 
-  // Mock functions (prevent API calls)
   const handleAddTask = (newTask) => {
     setTasks((prev) => ({
       ...prev,
@@ -75,62 +72,68 @@ const MockAdminDashboard = () => {
     });
   };
 
+  return {
+    tasks,
+    taskStats,
+    isAddModalOpen,
+    setIsAddModalOpen,
+    isEditModalOpen,
+    setIsEditModalOpen,
+    editingTask,
+    setEditingTask,
+    handleAddTask,
+    handleToggleLock,
+    navigate,
+  };
+};
+
+export default useMockAdminDashboard;
+
+const StatCard = ({ title, value }) => (
+  <div className="stat-card">
+    <h3>{title}</h3>
+    <p>{value}</p>
+  </div>
+);
+
+const MockAdminDashboard = () => {
+  const {
+    tasks,
+    taskStats,
+    isAddModalOpen,
+    setIsAddModalOpen,
+    isEditModalOpen,
+    setIsEditModalOpen,
+    editingTask,
+    handleAddTask,
+    handleToggleLock,
+    navigate,
+  } = useMockAdminDashboard();
+
   return (
     <div className="admin-dashboard">
       <h1 className="dashboard-title">Admin Dashboard</h1>
 
-      <div className="add-task-container" style={{ display: "flex", justifyContent: "flex-end", gap: "10px", marginBottom: "20px" }}>
-        <button
-          onClick={() => navigate("/adminManagement")}
-          className="admin-management-button"
-          style={{
-            background: "green",
-            color: "white",
-            border: "none",
-            padding: "10px 20px",
-            borderRadius: "5px",
-            cursor: "pointer",
-            fontSize: "16px",
-          }}
-        >
+      <div className="dashboard-actions">
+        <button onClick={() => navigate("/adminManagement")} className="admin-management-button">
           Admin Management
         </button>
-
-        <button
-          onClick={() => setIsAddModalOpen(true)}
-          className="add-task-button"
-          style={{
-            background: "#007bff",
-            color: "white",
-            border: "none",
-            padding: "10px 20px",
-            borderRadius: "5px",
-            cursor: "pointer",
-            fontSize: "16px",
-          }}
-        >
+        <button onClick={() => setIsAddModalOpen(true)} className="add-task-button">
           + Add Task
         </button>
       </div>
 
       <div className="dashboard-stats">
-        <div className="stat-card"><h3>To-Do</h3><p>{taskStats.todo}</p></div>
-        <div className="stat-card"><h3>In Progress</h3><p>{taskStats.inProgress}</p></div>
-        <div className="stat-card"><h3>Done</h3><p>{taskStats.done}</p></div>
-        <div className="stat-card"><h3>Completion Rate</h3><p>{taskStats.completedRate}%</p></div>
-        <div className="stat-card"><h3>Upcoming Due</h3><p>{taskStats.upcomingDue}</p></div>
+        {Object.entries(taskStats).map(([key, value]) => (
+          <StatCard key={key} title={key.replace(/([A-Z])/g, " $1")} value={value} />
+        ))}
       </div>
 
       <SearchBar />
 
       <div className="task-board">
         {Object.keys(tasks).map((status) => (
-          <AdminTaskList
-            key={status}
-            title={status}
-            tasks={tasks[status]}
-            onToggleLock={handleToggleLock}
-          />
+          <AdminTaskList key={status} title={status} tasks={tasks[status]} onToggleLock={handleToggleLock} />
         ))}
       </div>
 
@@ -151,21 +154,6 @@ const renderMockAdminManagement = () => {
 describe("AdminDashboard Component", () => {
   beforeEach(() => {
     fetch.mockClear();
-
-    fetch.mockImplementation((url) => {
-      if (url.includes("/api/tasks")) {
-        return Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              todo: [{ id: 1, title: "Task 1", status: "todo", locked: false, dueDate: "2025-03-10" }],
-              inProgress: [{ id: 2, title: "Task 2", status: "inProgress", locked: false, dueDate: "2025-03-12" }],
-              done: [{ id: 3, title: "Task 3", status: "done", locked: false, dueDate: "2025-03-15" }],
-            }),
-        });
-      }
-      return Promise.resolve({ ok: true }); // Default response for other requests
-    });
   });
 
 

--- a/frontend/src/_tests_/AdminTaskList.test.js
+++ b/frontend/src/_tests_/AdminTaskList.test.js
@@ -69,7 +69,7 @@ describe("AdminTaskList", () => {
   
     const modifiedSampleTasks = [
       { id: "1", title: "Task A", description: "Desc A", priority: "High", dueDate: "2025-02-10", locked: false },
-      { id: "2", title: "Task B", description: "Desc B", priority: "Medium", dueDate: "2025-02-15", locked: false }, // 确保任务未锁定
+      { id: "2", title: "Task B", description: "Desc B", priority: "Medium", dueDate: "2025-02-15", locked: false },
     ];
   
     const renderModifiedAdminTaskList = () => {

--- a/frontend/src/_tests_/LoginPage.test.js
+++ b/frontend/src/_tests_/LoginPage.test.js
@@ -2,19 +2,25 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import LoginBody from "../components/LoginBody";
 import axios from "axios";
+import LoginBody from "../components/LoginBody";
 import LoginPage from "../pages/LoginPage";
 
 jest.mock("axios");
 jest.spyOn(window, "alert").mockImplementation(() => {});
 
-const renderLoginBody = () => {
-  render(
-    <MemoryRouter>
-      <LoginBody />
-    </MemoryRouter>
-  );
+const renderWithRouter = (ui) => {
+  render(<MemoryRouter>{ui}</MemoryRouter>);
+};
+
+const fillAndSubmitLoginForm = async (email, password) => {
+  fireEvent.change(screen.getByRole("textbox", { name: /email/i }), {
+    target: { value: email },
+  });
+  fireEvent.change(screen.getByLabelText(/password/i), {
+    target: { value: password },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /login/i }));
 };
 
 describe("LoginBody", () => {
@@ -23,7 +29,7 @@ describe("LoginBody", () => {
   });
 
   test("renders LoginBody with input fields and login button", () => {
-    renderLoginBody();
+    renderWithRouter(<LoginBody />);
 
     expect(screen.getByTestId("login-body")).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/username or email/i)).toBeInTheDocument();
@@ -32,7 +38,7 @@ describe("LoginBody", () => {
   });
 
   test("does not submit if fields are empty", async () => {
-    renderLoginBody();
+    renderWithRouter(<LoginBody />);
 
     await userEvent.click(screen.getByRole("button", { name: /login/i }));
 
@@ -41,22 +47,15 @@ describe("LoginBody", () => {
 });
 
 describe("LoginPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   test("calls the backend API on form submission with correct credentials", async () => {
     axios.post.mockResolvedValueOnce({ data: { message: "Login successful" } });
 
-    render(
-      <MemoryRouter>
-        <LoginPage />
-      </MemoryRouter>
-    );
-
-    const emailInput = screen.getByLabelText(/email/i);
-    const passwordInput = screen.getByLabelText(/password/i);
-    const loginButton = screen.getByRole("button", { name: /login/i });
-
-    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
-    fireEvent.change(passwordInput, { target: { value: "password123" } });
-    fireEvent.click(loginButton);
+    renderWithRouter(<LoginPage />);
+    await fillAndSubmitLoginForm("test@example.com", "password123");
 
     await waitFor(() => {
       expect(axios.post).toHaveBeenCalledWith(
@@ -72,19 +71,8 @@ describe("LoginPage", () => {
   test("shows error alert when login fails", async () => {
     axios.post.mockRejectedValueOnce(new Error("Login failed"));
 
-    render(
-      <MemoryRouter>
-        <LoginPage />
-      </MemoryRouter>
-    );
-
-    const emailInput = screen.getByLabelText(/email/i);
-    const passwordInput = screen.getByLabelText(/password/i);
-    const loginButton = screen.getByRole("button", { name: /login/i });
-
-    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
-    fireEvent.change(passwordInput, { target: { value: "password123" } });
-    fireEvent.click(loginButton);
+    renderWithRouter(<LoginPage />);
+    await fillAndSubmitLoginForm("test@example.com", "password123");
 
     await waitFor(() => {
       expect(axios.post).toHaveBeenCalledWith(
@@ -94,11 +82,7 @@ describe("LoginPage", () => {
           password: "password123",
         }
       );
-    });
-
-    await waitFor(() => {
       expect(window.alert).toHaveBeenCalledWith("Login failed! Please try again later.");
     });
   });
-
 });

--- a/frontend/src/_tests_/LoginPage.test.js
+++ b/frontend/src/_tests_/LoginPage.test.js
@@ -1,13 +1,13 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom"; // Use for rendering without navigation
+import { MemoryRouter } from "react-router-dom";
 import LoginBody from "../components/LoginBody";
 import axios from "axios";
 import LoginPage from "../pages/LoginPage";
 
 jest.mock("axios");
-jest.spyOn(window, "alert").mockImplementation(() => {}); // Mock window.alert
+jest.spyOn(window, "alert").mockImplementation(() => {});
 
 const renderLoginBody = () => {
   render(
@@ -19,7 +19,7 @@ const renderLoginBody = () => {
 
 describe("LoginBody", () => {
   beforeEach(() => {
-    jest.clearAllMocks(); // Clear mocks before each test to avoid interference
+    jest.clearAllMocks();
   });
 
   test("renders LoginBody with input fields and login button", () => {
@@ -50,8 +50,8 @@ describe("LoginPage", () => {
       </MemoryRouter>
     );
 
-    const emailInput = screen.getByLabelText(/email/i); // Access by label text
-    const passwordInput = screen.getByLabelText(/password/i); // Access by label text
+    const emailInput = screen.getByLabelText(/email/i);
+    const passwordInput = screen.getByLabelText(/password/i);
     const loginButton = screen.getByRole("button", { name: /login/i });
 
     fireEvent.change(emailInput, { target: { value: "test@example.com" } });
@@ -70,7 +70,6 @@ describe("LoginPage", () => {
   });
 
   test("shows error alert when login fails", async () => {
-    // Mocking the axios.post to simulate a failed login
     axios.post.mockRejectedValueOnce(new Error("Login failed"));
 
     render(
@@ -97,7 +96,6 @@ describe("LoginPage", () => {
       );
     });
 
-    // Check if the alert for failed login is shown (assuming an alert is shown in case of failure)
     await waitFor(() => {
       expect(window.alert).toHaveBeenCalledWith("Login failed! Please try again later.");
     });

--- a/frontend/src/_tests_/SignupPage.test.js
+++ b/frontend/src/_tests_/SignupPage.test.js
@@ -6,13 +6,11 @@ import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 
-// Mock axios and useNavigate
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useNavigate: jest.fn(),
 }));
 
-// Create a mock instance of axios
 const mock = new MockAdapter(axios);
 
 const renderSignupPage = () => {
@@ -24,7 +22,7 @@ const renderSignupPage = () => {
 };
 
 beforeAll(() => {
-  process.env.REACT_APP_API_URL = "http://localhost:5000"; // Adjust based on your API base URL
+  process.env.REACT_APP_API_URL = "http://localhost:5000";
 });
 
 describe("SignupPage", () => {
@@ -35,7 +33,7 @@ describe("SignupPage", () => {
     useNavigate.mockReturnValue(navigate);
     jest.clearAllMocks();
     jest.spyOn(window, "alert").mockImplementation(() => {}); // Mock alert globally
-    mock.reset(); // Reset mock before each test
+    mock.reset();
   });
 
   test("clicking 'Login here' navigates to login page", async () => {
@@ -154,7 +152,6 @@ describe("SignupPage", () => {
   });
 
   test("should show alert on error when sign-up fails", async () => {
-    // Mock the POST request to /register to return an error
     mock.onPost(`${process.env.REACT_APP_API_URL}/register`).reply(400, {
       error: "User already exists",
     });
@@ -168,7 +165,6 @@ describe("SignupPage", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /sign up/i }));
 
-    // Wait for the error handling
     await waitFor(() => {
       expect(window.alert).toHaveBeenCalledWith("Sign up failed!");
     });

--- a/frontend/src/_tests_/SignupPage.test.js
+++ b/frontend/src/_tests_/SignupPage.test.js
@@ -21,6 +21,13 @@ const renderSignupPage = () => {
   );
 };
 
+const fillSignupForm = async (username, email, password, confirmPassword) => {
+  await userEvent.type(screen.getByRole("textbox", { name: /username/i }), username);
+  await userEvent.type(screen.getByRole("textbox", { name: /email/i }), email);
+  await userEvent.type(screen.getAllByLabelText(/password/i)[0], password);
+  await userEvent.type(screen.getAllByLabelText(/password/i)[1], confirmPassword);
+};
+
 beforeAll(() => {
   process.env.REACT_APP_API_URL = "http://localhost:5000";
 });
@@ -51,12 +58,7 @@ describe("SignupPage", () => {
     });
 
     renderSignupPage();
-
-    await userEvent.type(screen.getByRole("textbox", { name: /username/i }), "testuser");
-    await userEvent.type(screen.getByRole("textbox", { name: /email/i }), "test@example.com");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[0], "password123");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[1], "password123");
-
+    await fillSignupForm("testuser", "test@example.com", "password123", "password123");
     await userEvent.click(screen.getByRole("button", { name: /sign up/i }));
 
     expect(window.alert).toHaveBeenCalledWith("Sign up successful!");
@@ -69,12 +71,7 @@ describe("SignupPage", () => {
     });
 
     renderSignupPage();
-
-    await userEvent.type(screen.getByRole("textbox", { name: /username/i }), "testuser");
-    await userEvent.type(screen.getByRole("textbox", { name: /email/i }), "test@example.com");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[0], "password123");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[1], "password123");
-
+    await fillSignupForm("testuser", "test@example.com", "password123", "password123");
     await userEvent.click(screen.getByRole("button", { name: /sign up/i }));
 
     await waitFor(() => {
@@ -88,12 +85,7 @@ describe("SignupPage", () => {
     });
 
     renderSignupPage();
-
-    await userEvent.type(screen.getByRole("textbox", { name: /username/i }), "testuser");
-    await userEvent.type(screen.getByRole("textbox", { name: /email/i }), "test@example.com");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[0], "password123");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[1], "password123");
-
+    await fillSignupForm("testuser", "test@example.com", "password123", "password123");
     await userEvent.click(screen.getByRole("button", { name: /sign up/i }));
 
     expect(mock.history.post[0].data).toContain("testuser");
@@ -102,7 +94,6 @@ describe("SignupPage", () => {
 
   test("form submission fails if fields are empty", async () => {
     renderSignupPage();
-
     await userEvent.click(screen.getByRole("button", { name: /sign up/i }));
 
     expect(window.alert).toHaveBeenCalledWith("All fields must be filled!");
@@ -111,12 +102,7 @@ describe("SignupPage", () => {
 
   test("form submission fails if passwords do not match", async () => {
     renderSignupPage();
-
-    await userEvent.type(screen.getByRole("textbox", { name: /username/i }), "testuser");
-    await userEvent.type(screen.getByRole("textbox", { name: /email/i }), "test@example.com");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[0], "password123");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[1], "wrongpassword");
-
+    await fillSignupForm("testuser", "test@example.com", "password123", "wrongpassword");
     await userEvent.click(screen.getByRole("button", { name: /sign up/i }));
 
     expect(window.alert).toHaveBeenCalledWith("Passwords do not match");
@@ -125,12 +111,7 @@ describe("SignupPage", () => {
 
   test("form submission fails if email is invalid", async () => {
     renderSignupPage();
-
-    await userEvent.type(screen.getByRole("textbox", { name: /username/i }), "testuser");
-    await userEvent.type(screen.getByRole("textbox", { name: /email/i }), "invalid-email");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[0], "password123");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[1], "password123");
-
+    await fillSignupForm("testuser", "invalid-email", "password123", "password123");
     await userEvent.click(screen.getByRole("button", { name: /sign up/i }));
 
     expect(window.alert).toHaveBeenCalledWith("Invalid email format");
@@ -139,12 +120,7 @@ describe("SignupPage", () => {
 
   test("form submission fails if password is too short", async () => {
     renderSignupPage();
-
-    await userEvent.type(screen.getByRole("textbox", { name: /username/i }), "testuser");
-    await userEvent.type(screen.getByRole("textbox", { name: /email/i }), "test@example.com");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[0], "short");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[1], "short");
-
+    await fillSignupForm("testuser", "test@example.com", "short", "short");
     await userEvent.click(screen.getByRole("button", { name: /sign up/i }));
 
     expect(window.alert).toHaveBeenCalledWith("Password must be at least 8 characters long");
@@ -157,12 +133,7 @@ describe("SignupPage", () => {
     });
 
     renderSignupPage();
-
-    await userEvent.type(screen.getByRole("textbox", { name: /username/i }), "testuser");
-    await userEvent.type(screen.getByRole("textbox", { name: /email/i }), "test@example.com");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[0], "password123");
-    await userEvent.type(screen.getAllByLabelText(/password/i)[1], "password123");
-
+    await fillSignupForm("testuser", "test@example.com", "password123", "password123");
     await userEvent.click(screen.getByRole("button", { name: /sign up/i }));
 
     await waitFor(() => {


### PR DESCRIPTION
Refactored frontend tests:
- Add a render constant in each file that all tests can call on.
- Removed redundant comments.

In AdminDashboard.test.js:
- State logic is now in `useMockAdminDashboard`, making `mockAdminDashboard` cleaner.
- Added reusability with the `StatCard` component
- Removed inline styles as they are not needed in tests
- No duplicate fetch mocks inside the beforeEach()

In AdminTaskList.test.js:
- Reusable `renderAdminTaskList` now accepts different tasks and titles instead of defining a new fender function each time.
- Helper function `getButtons` to simplify button retrieval.
- Loops for assertions reduces the redundancy when checking rendered tasks.

In LoginPage.test.js:
- Extracted `renderWithRouter` Utility, avoiding repeatition of `<MemoryRouter>` in multiple places.
- Extracted `fillAndSubmitLoginForm` to reduce redundant `fireEvent.change()` calls.

In SignupPage.test.js:
- Removed repetitive code by creating a helper function `fillSignupForm()` to fill the form for each test.

Closes #177 