### PR TITLE
Remove the search bar and link button to the sign up page

### DIFF
--- a/frontend/src/components/CallToAction.js
+++ b/frontend/src/components/CallToAction.js
@@ -1,15 +1,13 @@
 import React from "react";
-
+import { useNavigate } from "react-router-dom";
 const CallToAction = () => {
+  const navigate = useNavigate();
   return (
     <section style={styles.container}>
       <h2>Ready to Boost Your Productivity?</h2>
-      <div style={styles.formContainer}>
-        <input type="email" placeholder="Email" style={styles.input} />
-        <button style={styles.button} onClick={() => alert("Sign Up Now!")}>
-        Sign Up Now
+      <button style={styles.button} onClick={() => navigate("/signup")}>
+       Get started
       </button>
-      </div>
     </section>
   );
 };

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -76,11 +76,7 @@ const Header = () => {
                     style={{ cursor: "pointer", fontSize: "1.2rem", marginRight: "15px" }} 
                 />
 
-                <div className="search-container">
-                    <input type="text" placeholder="Search..." className="search-input" />
-                    <FaSearch className="search-icon" />
-                </div>
-                
+               
 
                 {/* Updated notification icon with color from notification and click handler */}
                 <FaBell 

--- a/frontend/src/components/HeroSection.js
+++ b/frontend/src/components/HeroSection.js
@@ -8,9 +8,6 @@ const HeroSection = () => {
      
       <img src="/hero-image.png" alt="Hero" style={styles.image} />
       <br></br>
-      <button style={styles.button} onClick={() => alert("Sign Up Clicked")}>
-        Get Started
-      </button>
 
      
     </section>

--- a/frontend/src/css/header.css
+++ b/frontend/src/css/header.css
@@ -51,25 +51,6 @@
     gap: 15px;
 }
 
-.search-container {
-    position: relative;
-}
-
-.search-input {
-    padding: 5px 30px 5px 10px;
-    border-radius: 5px;
-    border: none;
-    outline: none;
-}
-
-.search-icon {
-    position: absolute;
-    right: 10px;
-    top: 50%;
-    transform: translateY(-50%);
-    color: #888;
-    cursor: pointer;
-}
 
 .btn {
     padding: 8px 16px;


### PR DESCRIPTION
Remove the search bar. 
Only keep one 'Get started' button. 
When the button 'Get started' has been clicked, jump to the signup page. 

#224 