### PR TITLE
Fix messages redirect & clear auth token upon logout

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -18,12 +18,12 @@ const Header = () => {
         if (isLoggedIn) {
             navigate("/chat"); // Send to chat if logged in
         } else {
-            navigate("/signup"); // Redirect to sign-up if not logged in
+            navigate("/login"); // Redirect to sign-up if not logged in
         }
     };
 
     const handleLogout = () => {
-        localStorage.setItem("token", "logged_out");
+        localStorage.removeItem("token"); // remove authentication once logged out
         navigate("/login");
       };
     const handleTasksClick = () => {


### PR DESCRIPTION
- Changed the redirect from `/signup` to `/login` when trying to access /chat while not logged in.
- Cleared the token from local storage instead of setting it to log out to prevent access to `/tasks` when logged out.

Closes #234 #228 