### PR TITLE
make sure task will not drop to bottom after updating

### DIFF
--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -335,17 +335,29 @@ const AdminDashboard = () => {
                              prevTasks.inProgress.some(t => t.task_id === updatedTask.task_id) ? "inProgress" :
                              "done";
   
+        const oldTaskIndex = prevTasks[oldStatusKey].findIndex(t => t.task_id === updatedTask.task_id);
+
+        // If the status hasn't changed, update the task in place
+        if (oldStatusKey === newStatusKey) {
+          const updatedList = [...prevTasks[oldStatusKey]];
+          updatedList[oldTaskIndex] = updatedTaskWithStringPriority; // Replace at the original index
+          return {
+            ...prevTasks,
+            [oldStatusKey]: updatedList,
+          };
+        }
+  
+        // If the status has changed, remove from old list and insert into new list at a preserved position
+        const oldList = prevTasks[oldStatusKey].filter(t => t.task_id !== updatedTask.task_id);
+        const newList = [...prevTasks[newStatusKey]];
+        newList.splice(oldTaskIndex < newList.length ? oldTaskIndex : newList.length, 0, updatedTaskWithStringPriority); // Insert at original index or end if out of bounds
+  
         return {
           ...prevTasks,
-          [oldStatusKey]: prevTasks[oldStatusKey].filter(t => t.task_id !== updatedTask.task_id),
-          [newStatusKey]: [
-            ...prevTasks[newStatusKey].filter(t => t.task_id !== updatedTask.task_id), 
-            updatedTaskWithStringPriority
-          ],
+          [oldStatusKey]: oldList,
+          [newStatusKey]: newList,
         };
-      });
-  
-      setIsEditModalOpen(false);
+      });setIsEditModalOpen(false);
     } catch (error) {
       console.error("Error updating task:", error);
     }

--- a/frontend/src/components/TaskBoard.js
+++ b/frontend/src/components/TaskBoard.js
@@ -225,30 +225,41 @@ const TaskBoard = () => {
         const oldStatusKey = prevTasks.todo.some(t => t.task_id === updatedTask.task_id) ? "todo" :
         prevTasks.inProgress.some(t => t.task_id === updatedTask.task_id) ? "inProgress" :
         "done";
-       
-        return {
-          ...prevTasks,
-          [oldStatusKey]: prevTasks[oldStatusKey].filter(t => t.task_id !== updatedTask.task_id),
-          [statusKey]: [
-            ...prevTasks[statusKey].filter(t => t.task_id !== updatedTask.task_id), 
-            updatedTask
-          ],
-        };
-      } else {
-        return {
-          ...prevTasks,
-          [statusKey]: [updatedTask, ...prevTasks[statusKey]],
-        };
-      }
-    });
+        const oldTaskIndex = prevTasks[oldStatusKey].findIndex(t => t.task_id === updatedTask.task_id);
 
-    setIsModalOpen(false);
-    setEditingTask(null);
-  } catch (error) {
-    console.error("Fetch error:", error);
-  }
+        // If the status hasn't changed, update the task in place
+        if (oldStatusKey === statusKey) {
+          const updatedList = [...prevTasks[oldStatusKey]];
+          updatedList[oldTaskIndex] = updatedTask; // Replace at the original index
+          return {
+            ...prevTasks,
+            [oldStatusKey]: updatedList,
+          };
+        }
+
+        // If the status has changed, remove from old list and insert into new list at preserved position
+        const oldList = prevTasks[oldStatusKey].filter(t => t.task_id !== updatedTask.task_id);
+        const newList = [...prevTasks[statusKey]];
+        newList.splice(oldTaskIndex < newList.length ? oldTaskIndex : newList.length, 0, updatedTask); // Insert at original index or end if out of bounds
+
+        return {
+          ...prevTasks,
+          [oldStatusKey]: oldList,
+          [statusKey]: newList,
+        };
+      } else {return {
+        ...prevTasks,
+        [statusKey]: [updatedTask, ...prevTasks[statusKey]],
+      };
+    }
+  });
+
+  setIsModalOpen(false);
+  setEditingTask(null);
+} catch (error) {
+  console.error("Fetch error:", error);
+}
 };
-
   // Function to add a user to an existing task from TaskList
   const handleAddUserToTask = async (taskId, userId) => {
     try {


### PR DESCRIPTION
make sure the task will not drop to the bottom after updating. (both admin dashboard and task board)
---- the task will not change position after being updated (by clicking the 'update task’ button)

#243 