### PR TITLE
Add default value for kanbanId

### DIFF
--- a/frontend/src/components/AddTask.js
+++ b/frontend/src/components/AddTask.js
@@ -13,7 +13,7 @@ const AddTask = ({ task, onSaveTask, onClose, availableUsers }) => {
     endDate: "",
     progress: 0,
     status: "todo",
-    kanbanId: null,
+    kanbanId: 1, // Set default kanbanId to 1 because we are assuming only 1 kanban board exists
     userId: null,
   });
 

--- a/frontend/src/components/TaskBoard.js
+++ b/frontend/src/components/TaskBoard.js
@@ -167,7 +167,7 @@ useEffect(() => {
     const priorityValue = priorityMap[taskData.priority] || parseInt(taskData.priority, 10) || null;
     const formattedTaskData = {
       id: taskData.id || null, 
-      kanban_id: taskData.kanban_id, 
+      kanban_id: taskData.kanban_id || 1, 
       user_id: taskData.user_id,
       title: taskData.title,
       description: taskData.description,


### PR DESCRIPTION
- kanban_id now properly inserts into the database when adding a task 
- Default value is set to 1 to reflect the ID of the kanban that is initialized

Closes #255 